### PR TITLE
Fix deprecated decorator

### DIFF
--- a/Chapter03/audio_player.py
+++ b/Chapter03/audio_player.py
@@ -46,7 +46,8 @@ class MediaLoader(metaclass=abc.ABCMeta):
     def play(self):
         pass
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def ext(self):
         pass
 


### PR DESCRIPTION
`@abc.abstractproperty` is deprecated since Python 3.3, use a combination of `@property` and `@abc.abstractmethod` instead.